### PR TITLE
Coerce HOME env var into string to avoid error in environments that doen't define it

### DIFF
--- a/lib/app_config/storage/yaml.rb
+++ b/lib/app_config/storage/yaml.rb
@@ -6,7 +6,7 @@ module AppConfig
     # YAML storage method.
     class YAML < Storage::Base
 
-      DEFAULT_PATH = File.expand_path(File.join(ENV['HOME'], '.app_config.yml'))
+      DEFAULT_PATH = File.expand_path(File.join(ENV['HOME'].to_s, '.app_config.yml'))
 
       # Loads `@data` with the YAML file located at `path`.
       # `@data` will be the Hashish that is accessed with `AppConfig[:key]`.


### PR DESCRIPTION
I noticed it in an app init script. The app fails to boot with:

```
app_config/storage/yaml.rb:9:in `join': can't convert nil into String (TypeError)
```
