### PR TITLE
Add default config for Base storage

### DIFF
--- a/lib/app_config.rb
+++ b/lib/app_config.rb
@@ -30,7 +30,7 @@ module AppConfig
       elsif @@options[:sqlite]
         @@storage = AppConfig::Storage::SQLite.new(@@options.delete(:sqlite))
       else
-        @@storage = AppConfig::Storage::Base.new
+        @@storage = AppConfig::Storage::Base.new(@@options)
       end
 
       yield @@storage if block_given?

--- a/lib/app_config/storage/base.rb
+++ b/lib/app_config/storage/base.rb
@@ -2,8 +2,8 @@ module AppConfig
   module Storage
     class Base
 
-      def initialize
-        @data = Storage::ConfigData.new
+      def initialize(options = nil)
+        @data = Storage::ConfigData.new(options)
       end
 
       def to_hash

--- a/spec/app_config/storage/base_spec.rb
+++ b/spec/app_config/storage/base_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe AppConfig::Storage::Base do
+
+  it 'accepts hash as default data' do
+    config_for(default: 'data')
+    AppConfig.default.should == 'data'
+  end
+
+end


### PR DESCRIPTION
README says:

> In it's simplest form, you can use it like so:
> 
> ``` ruby
> AppConfig.setup!(admin_email: 'admin@example.com')
> AppConfig.admin_email  # => 'admin@example.com'
> ```

But such simple setup didn't work and I've fixed it.
